### PR TITLE
fix: using hashrouter to work with page reloads

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import {React} from "react";
 import { Helmet, HelmetProvider } from 'react-helmet-async';
-import {BrowserRouter as Router, Route, Routes} from "react-router-dom";
+import {HashRouter as Router, Route, Routes} from "react-router-dom";
 import Home from "./components/Home";
 import AdventureDetail from "./components/AdventureDetail";
 import Articles from "./components/Articles";
@@ -13,9 +13,9 @@ import "./App.scss";
 const NavMenu = () => (
   <nav>
     <ul className="menu">
-      <li><a href={`/${window.location.search}`}>Adventures</a></li>
-      <li><a href={`/articles${window.location.search}`}>Magazine</a></li>
-      <li><a href={`/aboutus${window.location.search}`}>About Us</a></li>
+      <li><a href={`#/${window.location.search}`}>Adventures</a></li>
+      <li><a href={`#/articles${window.location.search}`}>Magazine</a></li>
+      <li><a href={`#/aboutus${window.location.search}`}>About Us</a></li>
     </ul>
   </nav>
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change the routing to HashRouting so Github Pages works correctly when doing a page reload in a subpage. At the moment it is causing 404s.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
