### PR TITLE
fix: read query params from the hash

### DIFF
--- a/src/utils/commons.js
+++ b/src/utils/commons.js
@@ -26,4 +26,12 @@ function getQueryStringForHashRouting() {
 	return window.location.search;
 }
 
-export { getArticle, getQueryStringForHashRouting };
+/**
+ * Same source of truth as {@link getQueryStringForHashRouting}: document search
+ * until params live in the hash (HashRouter), then parse the hash query.
+ */
+function getSearchParamsForHashRouting() {
+	return new URLSearchParams(getQueryStringForHashRouting());
+}
+
+export { getArticle, getQueryStringForHashRouting, getSearchParamsForHashRouting };

--- a/src/utils/fetchData.js
+++ b/src/utils/fetchData.js
@@ -1,3 +1,5 @@
+import { getSearchParamsForHashRouting } from "./commons";
+
 export const fetchData = async (path) => {
     const url = `${getAuthorHost()}/${path.split(":/")[1]}.infinity.json`;
     const data = await fetch(url, {headers: {"X-Aem-Affinity-Type": "api"}, credentials: "include"});
@@ -5,8 +7,7 @@ export const fetchData = async (path) => {
     return json;
 };
 export const getAuthorHost = () => {
-    const url = new URL(window.location.href);
-    const searchParams = new URLSearchParams(url.search);
+    const searchParams = getSearchParamsForHashRouting();
     if (searchParams.has("authorHost")) {
         return searchParams.get("authorHost");
     } else {
@@ -42,8 +43,7 @@ export const getImageURL = (obj) => {
 }
 
 export const getProtocol = () => {
-    const url = new URL(window.location.href);
-    const searchParams = new URLSearchParams(url.search);
+    const searchParams = getSearchParamsForHashRouting();
     if (searchParams.has("protocol")) {
         return searchParams.get("protocol");
     } else {
@@ -52,8 +52,7 @@ export const getProtocol = () => {
 }
 
 export const getService = () => {
-    const url = new URL(window.location.href);
-    const searchParams = new URLSearchParams(url.search);
+    const searchParams = getSearchParamsForHashRouting();
     if (searchParams.has("service")) {
         return searchParams.get("service");
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With HashRouter, the Universal Editor iframe URL can change from ?authorHost=…&publishHost=… on the document to /#/?authorHost=… in the hash. Code that only read window.location.search then saw no query string, so authorHost, publishHost, and related settings fell back to defaults until a full page refresh.

## Related Issue

[SITES-42681](https://jira.corp.adobe.com/browse/SITES-42681)

## Motivation and Context

Required so host and service configuration stay correct after navigation or reload when the app runs under hash URLs inside the UE iframe, without requiring a manual refresh.

## How Has This Been Tested?

1. Run app locally
2. Open https://localhost:3000/?authorHost=https://author-p15902-e145656-cmstg.adobeaemcloud.com&publishHost=https://publish-p15902-e145656-cmstg.adobeaemcloud.com
3. Add any component
4. Observe the issue is gone

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
